### PR TITLE
Fixes Nurse Spider Feeding

### DIFF
--- a/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/animal/giant_spider/nurse.dm
@@ -51,6 +51,9 @@
 	var/egg_type = /obj/effect/spider/eggcluster/small
 	var/web_type = /obj/effect/spider/stickyweb/dark
 
+/datum/ai_holder/simple_mob/melee/nurse_spider
+	mauling = TRUE		// The nurse puts mobs into webs by attacking, so it needs to attack in crit
+	handle_corpse = TRUE	// Lets the nurse wrap dead things
 
 /mob/living/simple_mob/animal/giant_spider/nurse/inject_poison(mob/living/L, target_zone)
 	..() // Inject the stoxin here.


### PR DESCRIPTION
Gives nurse spider mauling so they can attack in crit to wrap the mob in webs and handle_corpse so they can wrap dead mobs